### PR TITLE
increase default memory to -Xmx2048m

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,6 @@ jobs:
         echo 'org.gradle.caching=true' >> gradle.properties
         echo 'org.gradle.parallel=true' >> gradle.properties
         echo 'org.gradle.vfs.watch=true' >> gradle.properties
-        echo 'org.gradle.jvmargs=-Xmx2048m' >> gradle.properties
         echo 'android.native.buildOutput=verbose' >> gradle.properties
         ./gradlew buildAll
         ccache -s

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ android.enableR8.fullMode=true
 android.useAndroidX=true
 
 agpVersion=7.3.0
+org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
`./gradlew buildAll` fails with `JVM heap space is exhausted`, this pull request default memory to `-Xmx2048m`

```
> Task :manager:compileDebugKotlin
Expiring Daemon because JVM heap space is exhausted

FAILURE: Build failed with an exception.

* What went wrong:
Gradle build daemon has been stopped: JVM garbage collector thrashing and after running out of JVM memory

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

```