### PR TITLE
replace PackageInfo.CREATOR to hook creation of PackageInfo in all Parcel api

### DIFF
--- a/patch-loader/src/main/java/org/lsposed/lspatch/loader/LSPApplication.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/loader/LSPApplication.java
@@ -273,8 +273,20 @@ public class LSPApplication {
             }
         };
         XposedHelpers.setStaticObjectField(PackageInfo.class, "CREATOR", proxiedCreator);
-        Map<?, ?> mCreators = (Map<?, ?>) XposedHelpers.getStaticObjectField(Parcel.class, "mCreators");
-        mCreators.clear();
+        try {
+            Map<?, ?> mCreators = (Map<?, ?>) XposedHelpers.getStaticObjectField(Parcel.class, "mCreators");
+            mCreators.clear();
+        } catch (NoSuchFieldError ignore) {
+        } catch (Throwable e) {
+            Log.w(TAG, "fail to clear Parcel.mCreators", e);
+        }
+        try {
+            Map<?, ?> sPairedCreators = (Map<?, ?>) XposedHelpers.getStaticObjectField(Parcel.class, "sPairedCreators");
+            sPairedCreators.clear();
+        } catch (NoSuchFieldError ignore) {
+        } catch (Throwable e) {
+            Log.w(TAG, "fail to clear Parcel.sPairedCreators", e);
+        }
     }
 
     private static void doSigBypass(Context context) throws IllegalAccessException, ClassNotFoundException, IOException, NoSuchFieldException {


### PR DESCRIPTION
replace PackageInfo.CREATOR to hook creation of PackageInfo in all Parcel api

support both `getPackageInfo` and `getInstalledPackages`

```java
    private static void validateGetInstalledPackages(Context context) {
        PackageManager packageManager = context.getApplicationContext().getPackageManager();
        String packageName = context.getPackageName();
        for (PackageInfo pi : packageManager.getInstalledPackages(PackageManager.GET_SIGNING_CERTIFICATES)) {
            if (pi.packageName.equals(packageName)) {
                validateSignatureInPackageInfo(pi);
            }
        }
    }
```