### PR TITLE
Fix Manifest Parse Failure

### DIFF
--- a/axmlprinter/src/main/java/wind/android/content/res/StringBlock.java
+++ b/axmlprinter/src/main/java/wind/android/content/res/StringBlock.java
@@ -62,17 +62,22 @@ public class StringBlock {
         if (styleOffsetCount != 0) {
             block.m_styleOffsets = reader.readIntArray(styleOffsetCount);
         }
-        {
-            int size = ((stylesOffset == 0) ? chunkSize : stylesOffset) - stringsOffset;
-            block.m_strings = new byte[size];
-            reader.readFully(block.m_strings);
-        }
+
+        int size = ((stylesOffset == 0) ? chunkSize : stylesOffset) - stringsOffset;
+        block.m_strings = new byte[size];
+        reader.readFully(block.m_strings);
+
         if (stylesOffset != 0) {
-            int size = (chunkSize - stylesOffset);
-            if ((size % 4) != 0) {
-                throw new IOException("Style data size is not multiple of 4 (" + size + ").");
+            size = (chunkSize - stylesOffset);
+			block.m_styles = reader.readIntArray(size / 4);
+
+			int remaining = size % 4;
+            if (remaining >= 1) {
+                while (remaining-- > 0) {
+                    reader.readByte();
+                }
             }
-            block.m_styles = reader.readIntArray(size / 4);
+            
         }
 
         return block;


### PR DESCRIPTION
Recently encountered Multiple apps where LSPatch failed to parse AndroidManifest.xml. Upon further debugging found that we throw an error when style sizes don't adhere to a 4-byte boundary. We can safely ignore this and move forward since we are anyways not using `block.m_styles` anywhere in the code. Have checked multiple other AXML parsers wherein they too do the same thing