### PR TITLE
Remove mandatory original signature check

### DIFF
--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -205,7 +205,7 @@ public class LSPatch {
                 throw new PatchError("Failed to register signer", e);
             }
 
-            String originalSignature = "";
+            String originalSignature = null;
             if (sigbypassLevel > 0) {
                 originalSignature  = ApkSignatureHelper.getApkSignInfo(srcApkFile.getAbsolutePath());
                 if (originalSignature == null || originalSignature.isEmpty()) {

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -205,11 +205,14 @@ public class LSPatch {
                 throw new PatchError("Failed to register signer", e);
             }
 
-            final String originalSignature = ApkSignatureHelper.getApkSignInfo(srcApkFile.getAbsolutePath());
-            if (originalSignature == null || originalSignature.isEmpty()) {
-                throw new PatchError("get original signature failed");
+            String originalSignature = "";
+            if (sigbypassLevel > 0) {
+                originalSignature  = ApkSignatureHelper.getApkSignInfo(srcApkFile.getAbsolutePath());
+                if (originalSignature == null || originalSignature.isEmpty()) {
+                    throw new PatchError("get original signature failed");
+                }
+                logger.d("Original signature\n" + originalSignature);
             }
-            logger.d("Original signature\n" + originalSignature);
 
             // copy out manifest file from zlib
             var manifestEntry = srcZFile.get(ANDROID_MANIFEST_XML);


### PR DESCRIPTION
We are unnecessary fetching original signature even when signature bypass level is not greater than 0. Due to which some apps which were not signed were failing to be patched with error "get original signature failed".