### PR TITLE
Fix isolated process using split APKs

### DIFF
--- a/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/NewPatchViewModel.kt
+++ b/manager/src/main/java/org/lsposed/lspatch/ui/viewmodel/NewPatchViewModel.kt
@@ -90,7 +90,7 @@ class NewPatchViewModel : ViewModel() {
         Log.d(TAG, "Submit patch")
         if (useManager) embeddedModules = emptyList()
         patchOptions = Patcher.Options(
-            config = PatchConfig(useManager, debuggable, overrideVersionCode, sigBypassLevel, null, null),
+            config = PatchConfig(useManager, debuggable, overrideVersionCode, sigBypassLevel, null, null, null),
             apkPaths = listOf(patchApp.app.sourceDir) + (patchApp.app.splitSourceDirs ?: emptyArray()),
             embeddedModules = embeddedModules.flatMap { listOf(it.app.sourceDir) + (it.app.splitSourceDirs ?: emptyArray()) }
         )

--- a/meta-loader/build.gradle.kts
+++ b/meta-loader/build.gradle.kts
@@ -44,4 +44,5 @@ dependencies {
     compileOnly(projects.hiddenapi.stubs)
     implementation(projects.share.java)
     implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3")
+    implementation("com.google.code.gson:gson:2.10")
 }

--- a/meta-loader/build.gradle.kts
+++ b/meta-loader/build.gradle.kts
@@ -44,5 +44,4 @@ dependencies {
     compileOnly(projects.hiddenapi.stubs)
     implementation(projects.share.java)
     implementation("org.lsposed.hiddenapibypass:hiddenapibypass:4.3")
-    implementation("com.google.code.gson:gson:2.10")
 }

--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -2,6 +2,7 @@ package org.lsposed.lspatch.metaloader;
 
 import android.annotation.SuppressLint;
 import android.app.AppComponentFactory;
+import android.app.ActivityThread;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.IPackageManager;
 import android.os.Build;
@@ -19,6 +20,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -90,8 +92,12 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
                 }
                 soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
             }
-
-            System.load(soPath);
+            if (ActivityThread.currentActivityThread() != null) {
+                Log.d(TAG, "LSPAppComponentFactoryStub for process: " + ActivityThread.currentProcessName());
+                System.load(soPath);
+            } else {
+                Log.d(TAG, "ActivityThread.currentActivityThread is null, dumping stack trace\n" + Arrays.toString(Thread.currentThread().getStackTrace()).replace( ',', '\n' ));
+            }
         } catch (Throwable e) {
             throw new ExceptionInInitializerError(e);
         }

--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -96,7 +95,7 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
                 Log.d(TAG, "LSPAppComponentFactoryStub for process: " + ActivityThread.currentProcessName());
                 System.load(soPath);
             } else {
-                Log.d(TAG, "ActivityThread.currentActivityThread is null, dumping stack trace\n" + Arrays.toString(Thread.currentThread().getStackTrace()).replace( ',', '\n' ));
+                Log.d(TAG, "Skip LSPAppComponentFactoryStub since AppZygoteInit is running");
             }
         } catch (Throwable e) {
             throw new ExceptionInInitializerError(e);

--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPZygotePreloadStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPZygotePreloadStub.java
@@ -6,8 +6,6 @@ import android.app.ZygotePreload;
 import android.content.pm.ApplicationInfo;
 import android.util.Log;
 
-import com.google.gson.Gson;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.InputStream;
@@ -15,39 +13,37 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
-import org.lsposed.lspatch.share.PatchConfig;
+import org.json.JSONObject;
 
 /**
  * Created by JingMatrix
  */
 public class LSPZygotePreloadStub implements android.app.ZygotePreload {
     private static final String TAG = "LSPatch-MetaLoader";
-	private static PatchConfig config;
+    private static JSONObject config;
 
     @Override
     public void doPreload(ApplicationInfo appInfo) {
-        String originApkPath = Paths.get(appInfo.sourceDir).getParent().toString() + "/split_original.apk";
-		appInfo.sourceDir = originApkPath;
-		var cl = LSPZygotePreloadStub.class.getClassLoader();
-		try (var is = cl.getResourceAsStream(CONFIG_ASSET_PATH)) {
-			BufferedReader streamReader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-			config = new Gson().fromJson(streamReader, PatchConfig.class);
-            appInfo.appComponentFactory = config.appComponentFactory;
-			Log.d(TAG, "appComponentFactory should be " + config.appComponentFactory);
-			Log.d(TAG, "zygotePreloadName should be " + config.zygotePreloadName);
-		} catch (IOException e) {
-			Log.e(TAG, "Failed to load config file");
-			return;
-		}
+        String originalApkPath = Paths.get(appInfo.sourceDir).getParent().toString() + "/split_original.apk";
+        appInfo.sourceDir = originalApkPath;
+        var cl = LSPZygotePreloadStub.class.getClassLoader();
+        try (var is = cl.getResourceAsStream(CONFIG_ASSET_PATH)) {
+            BufferedReader streamReader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+            config = new JSONObject(streamReader.lines().collect(Collectors.joining()));
+            appInfo.appComponentFactory = config.getString("appComponentFactory");
+        } catch (Throwable e) {
+            Log.e(TAG, "Failed to load config file", e);
+            return;
+        }
 
-		try {
-			Class<?> originalPreload = cl.loadClass(config.zygotePreloadName);
-			Method originalDoPreload = originalPreload.getDeclaredMethod("doPreload", ApplicationInfo.class);
-			originalDoPreload.invoke(originalPreload.getDeclaredConstructor().newInstance(), appInfo);
-		} catch (Throwable e) {
-			Log.d(TAG, "Fail to call original ZygotePreload", e);
-		}
+        try {
+            Class<?> originalPreload = cl.loadClass(config.getString("zygotePreloadName"));
+            Method originalDoPreload = originalPreload.getDeclaredMethod("doPreload", ApplicationInfo.class);
+            originalDoPreload.invoke(originalPreload.getDeclaredConstructor().newInstance(), appInfo);
+        } catch (Throwable e) {
+            Log.d(TAG, "Fail to call original ZygotePreload", e);
+        }
     }
 }

--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPZygotePreloadStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPZygotePreloadStub.java
@@ -1,0 +1,50 @@
+package org.lsposed.lspatch.metaloader;
+
+import static org.lsposed.lspatch.share.Constants.CONFIG_ASSET_PATH;
+
+import android.app.ZygotePreload;
+import android.content.pm.ApplicationInfo;
+import android.util.Log;
+
+import com.google.gson.Gson;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import org.lsposed.lspatch.share.PatchConfig;
+
+/**
+ * Created by JingMatrix
+ */
+public class LSPZygotePreloadStub implements android.app.ZygotePreload {
+    private static final String TAG = "LSPatch-MetaLoader";
+
+    @Override
+    public void doPreload(ApplicationInfo appInfo) {
+        String originApkPath = Paths.get(appInfo.sourceDir).getParent().toString() + "/split_original.apk";
+		appInfo.sourceDir = originApkPath;
+		var cl = LSPZygotePreloadStub.class.getClassLoader();
+		try (var is = cl.getResourceAsStream(CONFIG_ASSET_PATH)) {
+			BufferedReader streamReader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+			PatchConfig config = new Gson().fromJson(streamReader, PatchConfig.class);
+            appInfo.appComponentFactory = config.appComponentFactory;
+		} catch (IOException e) {
+			Log.e(TAG, "Failed to load config file");
+			return;
+		}
+
+		try {
+			Class<?> originalPreload = cl.loadClass("org.chromium.content_public.app.ZygotePreload");
+			Method originalDoPreload = originalPreload.getDeclaredMethod("doPreload", ApplicationInfo.class);
+			originalDoPreload.invoke(originalPreload.getDeclaredConstructor().newInstance(), appInfo);
+		} catch (Throwable e) {
+			Log.d(TAG, "Fail to call original ZygotePreload", e);
+		}
+    }
+}

--- a/patch-loader/src/main/java/org/lsposed/lspatch/loader/LSPApplication.java
+++ b/patch-loader/src/main/java/org/lsposed/lspatch/loader/LSPApplication.java
@@ -69,11 +69,11 @@ public class LSPApplication {
         var context = createLoadedApkWithContext();
 
         if (isIsolated()) {
-			XLog.d(TAG, "Skip isolated process");
+            XLog.d(TAG, "Skip isolated process");
             return;
         } else if (context == null) {
             XLog.e(TAG, "Error when creating context");
-		}
+        }
 
         Log.d(TAG, "Initialize service client");
         ILSPApplicationService service;
@@ -118,10 +118,10 @@ public class LSPApplication {
             Log.i(TAG, "Use manager: " + config.useManager);
             Log.i(TAG, "Signature bypass level: " + config.sigBypassLevel);
 
-            String originApkPath = Paths.get(appInfo.sourceDir).getParent().toString() + "/split_original.apk";
+            String originalApkPath = Paths.get(appInfo.sourceDir).getParent().toString() + "/split_original.apk";
 
-            appInfo.sourceDir = originApkPath;
-            appInfo.publicSourceDir = originApkPath;
+            appInfo.sourceDir = originalApkPath;
+            appInfo.publicSourceDir = originalApkPath;
             appInfo.appComponentFactory = config.appComponentFactory;
 
             var mPackages = (Map<?, ?>) XposedHelpers.getObjectField(activityThread, "mPackages");

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -5,6 +5,7 @@ import static org.lsposed.lspatch.share.Constants.EMBEDDED_MODULES_ASSET_PATH;
 import static org.lsposed.lspatch.share.Constants.LOADER_DEX_ASSET_PATH;
 import static org.lsposed.lspatch.share.Constants.ORIGINAL_APK_ASSET_PATH;
 import static org.lsposed.lspatch.share.Constants.PROXY_APP_COMPONENT_FACTORY;
+import static org.lsposed.lspatch.share.Constants.PROXY_ZYGOTE_PRELOAD;
 
 import com.android.tools.build.apkzlib.sign.SigningExtension;
 import com.android.tools.build.apkzlib.sign.SigningOptions;
@@ -338,6 +339,7 @@ public class LSPatch {
         } else {
             property.addApplicationAttribute(new AttributeItem(NodeValue.Application.DEBUGGABLE, debuggableFlag));
             property.addApplicationAttribute(new AttributeItem("appComponentFactory", PROXY_APP_COMPONENT_FACTORY));
+		    property.addApplicationAttribute(new AttributeItem("zygotePreloadName", PROXY_ZYGOTE_PRELOAD));
             property.addMetaData(new ModificationProperty.MetaData("lspatch", metadata));
         }
         // TODO: replace query_all with queries -> manager

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -235,20 +235,23 @@ public class LSPatch {
 
             // parse the app appComponentFactory full name from the manifest file
             final String appComponentFactory;
+			final String zygotePreloadName;
             int minSdkVersion;
             try (var is = manifestEntry.open()) {
                 var pair = ManifestParser.parseManifestFile(is);
                 if (pair == null)
                     throw new PatchError("Failed to parse AndroidManifest.xml");
                 appComponentFactory = pair.appComponentFactory;
+				zygotePreloadName = pair.zygotePreloadName;
                 minSdkVersion = pair.minSdkVersion;
                 logger.d("original appComponentFactory class: " + appComponentFactory);
+                logger.d("original zygotePreloadName class: " + zygotePreloadName);
                 logger.d("original minSdkVersion: " + minSdkVersion);
             }
 
             logger.i("Patching apk...");
             // modify manifest
-            final var config = new PatchConfig(useManager, debuggableFlag, overrideVersionCode, sigbypassLevel, originalSignature, appComponentFactory);
+            final var config = new PatchConfig(useManager, debuggableFlag, overrideVersionCode, sigbypassLevel, originalSignature, appComponentFactory, zygotePreloadName);
             final var configBytes = new Gson().toJson(config).getBytes(StandardCharsets.UTF_8);
             final var metadata = Base64.getEncoder().encodeToString(configBytes);
             try (var baseIs = new ByteArrayInputStream(modifyManifestFile(manifestEntry.open(), metadata, minSdkVersion, false));

--- a/patch/src/main/java/org/lsposed/patch/LSPatch.java
+++ b/patch/src/main/java/org/lsposed/patch/LSPatch.java
@@ -235,14 +235,14 @@ public class LSPatch {
 
             // parse the app appComponentFactory full name from the manifest file
             final String appComponentFactory;
-			final String zygotePreloadName;
+            final String zygotePreloadName;
             int minSdkVersion;
             try (var is = manifestEntry.open()) {
                 var pair = ManifestParser.parseManifestFile(is);
                 if (pair == null)
                     throw new PatchError("Failed to parse AndroidManifest.xml");
                 appComponentFactory = pair.appComponentFactory;
-				zygotePreloadName = pair.zygotePreloadName;
+                zygotePreloadName = pair.zygotePreloadName;
                 minSdkVersion = pair.minSdkVersion;
                 logger.d("original appComponentFactory class: " + appComponentFactory);
                 logger.d("original zygotePreloadName class: " + zygotePreloadName);
@@ -342,7 +342,7 @@ public class LSPatch {
         } else {
             property.addApplicationAttribute(new AttributeItem(NodeValue.Application.DEBUGGABLE, debuggableFlag));
             property.addApplicationAttribute(new AttributeItem("appComponentFactory", PROXY_APP_COMPONENT_FACTORY));
-		    property.addApplicationAttribute(new AttributeItem("zygotePreloadName", PROXY_ZYGOTE_PRELOAD));
+            property.addApplicationAttribute(new AttributeItem("zygotePreloadName", PROXY_ZYGOTE_PRELOAD));
             property.addMetaData(new ModificationProperty.MetaData("lspatch", metadata));
         }
         // TODO: replace query_all with queries -> manager

--- a/patch/src/main/java/org/lsposed/patch/util/ManifestParser.java
+++ b/patch/src/main/java/org/lsposed/patch/util/ManifestParser.java
@@ -18,7 +18,7 @@ public class ManifestParser {
         AxmlParser parser = new AxmlParser(Utils.getBytesFromInputStream(is));
         String packageName = null;
         String appComponentFactory = null;
-		String zygotePreloadName = null;
+        String zygotePreloadName = null;
         int minSdkVersion = 0;
         try {
 
@@ -87,14 +87,14 @@ public class ManifestParser {
     public static class Pair {
         public String packageName;
         public String appComponentFactory;
-		public String zygotePreloadName;
+        public String zygotePreloadName;
 
         public int minSdkVersion;
 
         public Pair(String packageName, String appComponentFactory, String zygotePreloadName, int minSdkVersion) {
             this.packageName = packageName;
             this.appComponentFactory = appComponentFactory;
-			this.zygotePreloadName = zygotePreloadName;
+            this.zygotePreloadName = zygotePreloadName;
             this.minSdkVersion = minSdkVersion;
         }
     }

--- a/patch/src/main/java/org/lsposed/patch/util/ManifestParser.java
+++ b/patch/src/main/java/org/lsposed/patch/util/ManifestParser.java
@@ -18,6 +18,7 @@ public class ManifestParser {
         AxmlParser parser = new AxmlParser(Utils.getBytesFromInputStream(is));
         String packageName = null;
         String appComponentFactory = null;
+		String zygotePreloadName = null;
         int minSdkVersion = 0;
         try {
 
@@ -50,11 +51,16 @@ public class ManifestParser {
                             appComponentFactory = parser.getAttrValue(i).toString();
                         }
 
+                        if ("zygotePreloadName".equals(attrName)) {
+                            zygotePreloadName = parser.getAttrValue(i).toString();
+                        }
+
                         if (packageName != null && packageName.length() > 0 &&
                                 appComponentFactory != null && appComponentFactory.length() > 0 &&
+                                zygotePreloadName != null && zygotePreloadName.length() > 0 &&
                                 minSdkVersion > 0
                         ) {
-                            return new Pair(packageName, appComponentFactory, minSdkVersion);
+                            return new Pair(packageName, appComponentFactory, zygotePreloadName, minSdkVersion);
                         }
                     }
                 } else if (type == AxmlParser.END_TAG) {
@@ -65,7 +71,7 @@ public class ManifestParser {
             return null;
         }
 
-        return new Pair(packageName, appComponentFactory, minSdkVersion);
+        return new Pair(packageName, appComponentFactory, zygotePreloadName, minSdkVersion);
     }
 
     /**
@@ -81,12 +87,14 @@ public class ManifestParser {
     public static class Pair {
         public String packageName;
         public String appComponentFactory;
+		public String zygotePreloadName;
 
         public int minSdkVersion;
 
-        public Pair(String packageName, String appComponentFactory, int minSdkVersion) {
+        public Pair(String packageName, String appComponentFactory, String zygotePreloadName, int minSdkVersion) {
             this.packageName = packageName;
             this.appComponentFactory = appComponentFactory;
+			this.zygotePreloadName = zygotePreloadName;
             this.minSdkVersion = minSdkVersion;
         }
     }

--- a/share/java/src/main/java/org/lsposed/lspatch/share/Constants.java
+++ b/share/java/src/main/java/org/lsposed/lspatch/share/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
 
     final static public String PATCH_FILE_SUFFIX = "-lspatched.apk";
     final static public String PROXY_APP_COMPONENT_FACTORY = "org.lsposed.lspatch.metaloader.LSPAppComponentFactoryStub";
+    final static public String PROXY_ZYGOTE_PRELOAD = "org.lsposed.lspatch.metaloader.LSPZygotePreloadStub";
     final static public String MANAGER_PACKAGE_NAME = "org.lsposed.lspatch";
     final static public int MIN_ROLLING_VERSION_CODE = 348;
 

--- a/share/java/src/main/java/org/lsposed/lspatch/share/PatchConfig.java
+++ b/share/java/src/main/java/org/lsposed/lspatch/share/PatchConfig.java
@@ -8,6 +8,7 @@ public class PatchConfig {
     public final int sigBypassLevel;
     public final String originalSignature;
     public final String appComponentFactory;
+    public final String zygotePreloadName;
     public final LSPConfig lspConfig;
 
     public PatchConfig(
@@ -16,7 +17,8 @@ public class PatchConfig {
             boolean overrideVersionCode,
             int sigBypassLevel,
             String originalSignature,
-            String appComponentFactory
+            String appComponentFactory,
+			String zygotePreloadName
     ) {
         this.useManager = useManager;
         this.debuggable = debuggable;
@@ -24,6 +26,7 @@ public class PatchConfig {
         this.sigBypassLevel = sigBypassLevel;
         this.originalSignature = originalSignature;
         this.appComponentFactory = appComponentFactory;
+		this.zygotePreloadName = zygotePreloadName;
         this.lspConfig = LSPConfig.instance;
     }
 }

--- a/share/java/src/main/java/org/lsposed/lspatch/share/PatchConfig.java
+++ b/share/java/src/main/java/org/lsposed/lspatch/share/PatchConfig.java
@@ -18,7 +18,7 @@ public class PatchConfig {
             int sigBypassLevel,
             String originalSignature,
             String appComponentFactory,
-			String zygotePreloadName
+            String zygotePreloadName
     ) {
         this.useManager = useManager;
         this.debuggable = debuggable;
@@ -26,7 +26,7 @@ public class PatchConfig {
         this.sigBypassLevel = sigBypassLevel;
         this.originalSignature = originalSignature;
         this.appComponentFactory = appComponentFactory;
-		this.zygotePreloadName = zygotePreloadName;
+        this.zygotePreloadName = zygotePreloadName;
         this.lspConfig = LSPConfig.instance;
     }
 }


### PR DESCRIPTION
Solve issue #190 : for isolated process, it is impossible to extract original APK from assets.

Currently, we still need to work on the `android:zygotePreloadName` problem, which causes that `ActivityManager` fails for isolated processes having the  `android:useAppZygote` attribute .

See docs on [ZygotePreload](https://developer.android.com/reference/android/app/ZygotePreload).