### PR TITLE
Put original dex files in patched APK

### DIFF
--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -2,6 +2,7 @@ package org.lsposed.lspatch.metaloader;
 
 import android.annotation.SuppressLint;
 import android.app.AppComponentFactory;
+import android.app.ActivityThread;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.IPackageManager;
 import android.os.Build;
@@ -91,7 +92,9 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
                 soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
             }
 
-            System.load(soPath);
+            if (ActivityThread.currentActivityThread() != null) {
+                System.load(soPath);
+            }
         } catch (Throwable e) {
             throw new ExceptionInInitializerError(e);
         }


### PR DESCRIPTION
This will fix the isolated process problem, where we cannot hook `ActivityThread` invoked after `AppZygoteInit`:

1. Count the number of dex files and rename classes.dex correctly.
2. Skip loading lspatch.so when currentActivityThread is null.

Only the classLoader for isolated process is not clean.
For normal activities, `appLoadedApk` offers a clean classloader.