### PR TITLE
Handling duplicate System.load calls

### DIFF
--- a/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
+++ b/meta-loader/src/main/java/org/lsposed/lspatch/metaloader/LSPAppComponentFactoryStub.java
@@ -91,7 +91,13 @@ public class LSPAppComponentFactoryStub extends AppComponentFactory {
                 soPath = cl.getResource("assets/lspatch/so/" + libName + "/liblspatch.so").getPath().substring(5);
             }
 
-            System.load(soPath);
+            try {
+                System.load(soPath);
+            } catch (UnsatisfiedLinkError error) {
+                // Catching the error to handle duplicate loading of library
+                Log.e(TAG, "Failed to load liblspatch.so", error);
+            }
+
         } catch (Throwable e) {
             throw new ExceptionInInitializerError(e);
         }


### PR DESCRIPTION
We have seen apps to be crashing due to multiple System.load calls.
As seen from the log lines:
```
06-01 16:43:41.615 I/LSPosed-Bridge(16031): Caused by: java.lang.UnsatisfiedLinkError: Shared library "/data/app/com.example.sample-some_random_string/base.apk!/assets/lspatch/so/arm64-v8a/liblspatch.so" already opened by ClassLoader 0x1c7(dalvik.system.PathClassLoader[DexPathList[[zip file "/data/app/com.example.sample-some_random_string/base.apk"],nativeLibraryDirectories=[/data/app/com.example.sample-some_random_string/lib/arm64, /data/app/com.example.sample-some_random_string/base.apk!/lib/arm64-v8a, /system/lib64, /product/lib64]]]); can't open in ClassLoader 0x7ffc869ecc(dalvik.system.PathClassLoader[DexPathList[[zip file "/data/user/0/org.houstonmethodist.methodistmobile.debug/cache/lspatch/origin/4198609975.apk", zip file "/data/app/com.example.sample-some_random_string/base.apk"],nativeLibraryDirectories=[/data/app/com.example.sample-some_random_string/lib/arm64, /data/user/0/org.houstonmethodist.methodistmobile.debug/cache/lspatch/origin/4198609975.apk!/lib/arm64-v8a, /system/lib64, /product/lib64]]])
```
Looks like we are trying to load liblspatch.so file even when it was loaded earlier by the ClassLoader, due to which it is causing the error.

This is similar to this issue: https://stackoverflow.com/questions/54155086/preventing-duplicate-system-loadlibrary-calls-when-dynamically-loading-reloading

Have added try ... catch block around `System.load` method to handle exceptions / error raised from it, and have added log line to debug the issue in cases of actual errors.